### PR TITLE
feat(nvim): use skim as fzf-lua backend

### DIFF
--- a/config/nvim/lazy-lock.json
+++ b/config/nvim/lazy-lock.json
@@ -26,7 +26,7 @@
   "focus.nvim": { "branch": "master", "commit": "d76338e58e49f844e8f6a7aff16a74a2a55a80ef" },
   "friendly-snippets": { "branch": "main", "commit": "efff286dd74c22f731cdec26a70b46e5b203c619" },
   "fsread.nvim": { "branch": "main", "commit": "a637bf048f733def7c5c46f5bf482f93a8311b29" },
-  "fzf-lua": { "branch": "main", "commit": "caee13203d6143d691710c34f85ad6441fe3f535" },
+  "fzf-lua": { "branch": "main", "commit": "bde73a6886b607246095aa59f396de5e0d036890" },
   "git-worktree.nvim": { "branch": "main", "commit": "3ad8c17a3d178ac19be925284389c14114638ebb" },
   "gitsigns.nvim": { "branch": "main", "commit": "3c76f7fabac723aa682365ef782f88a83ccdb4ac" },
   "harpoon": { "branch": "master", "commit": "1bc17e3e42ea3c46b33c0bbad6a880792692a1b3" },

--- a/config/nvim/lua/plugins/fzf.lua
+++ b/config/nvim/lua/plugins/fzf.lua
@@ -9,6 +9,7 @@ local M = {
 
 M.opts = {
   "default-title",
+  fzf_bin = "sk",
   keymap = {
     builtin = {
       true,

--- a/config/nvim/lua/plugins/fzf.lua
+++ b/config/nvim/lua/plugins/fzf.lua
@@ -10,6 +10,7 @@ local M = {
 M.opts = {
   "default-title",
   fzf_bin = "sk",
+  fzf_opts = { ["--algo"] = "frizbee" },
   keymap = {
     builtin = {
       true,

--- a/home/default.nix
+++ b/home/default.nix
@@ -67,6 +67,7 @@ in
       # useful tools
       fd
       ripgrep
+      skim
       comma
       tldr
       dua

--- a/home/default.nix
+++ b/home/default.nix
@@ -67,7 +67,7 @@ in
       # useful tools
       fd
       ripgrep
-      skim
+      unstable.skim
       comma
       tldr
       dua


### PR DESCRIPTION
Closes #134

Replace fzf binary with skim (`sk`) in fzf-lua plugin. Shell-level fzf remains unchanged.